### PR TITLE
updating lodash version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "basic-auth": "^1.0.3",
     "body-parser": "^1.14.2",
     "express": "^4.13.3",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.11",
     "minimist": "^1.2.0",
     "morgan": "^1.8.1",
     "request": "^2.79.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,10 +582,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 md5.js@1.3.4:
   version "1.3.4"


### PR DESCRIPTION
Updating `lodash` to `^4.17.11` resolves 2 low/moderate package.json `dependencies` vulnerabilities.  I didn't have a working setup to actually test that these changes don't break anything, but as best as I could tell this repo only uses `_.has` and `_.isObject` so hopefully the update is low risk.  Feel free to test before approving if you have a working setup.